### PR TITLE
Require AnyEvent::HTTPD

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,9 +7,9 @@ requires 'Moose';
 requires 'AnyEvent' => '5.12';
 requires 'JSON::XS' => '2.22';  # For incremental parsing
 requires 'JSON::RPC::Common';
+requires 'AnyEvent::HTTPD';
 
 recommends 'AnyEvent::HTTP';
-recommends 'AnyEvent::HTTPD';
 
 test_requires 'Test::More';
 test_requires 'Test::TCP';
@@ -18,6 +18,7 @@ author_tests('xt');
 use_test_base;
 
 auto_include;
+auto_install;
 githubmeta;
 
 WriteAll;


### PR DESCRIPTION
Hi,
The module failes to install because AnyEvent::HTTPD is only recommended and not required in Makefile.PL .

This is what it displays when I try to install the module:
" 
Tried to use 'AnyEvent::JSONRPC::HTTP::Server'.
#     Error:  Can't locate AnyEvent/HTTPD.pm in @INC (you may need to install the AnyEvent::HTTPD module) ...
"

This pull request fixes this problem!
