### PR TITLE
Use Moose instead of Any::Moose

### DIFF
--- a/lib/AnyEvent/JSONRPC/Client.pm
+++ b/lib/AnyEvent/JSONRPC/Client.pm
@@ -1,8 +1,8 @@
 package AnyEvent::JSONRPC::Client;
 
-use Any::Moose;
+use Moose;
 
-no Any::Moose;
+no Moose;
 
 __PACKAGE__->meta->make_immutable;
 

--- a/lib/AnyEvent/JSONRPC/CondVar.pm
+++ b/lib/AnyEvent/JSONRPC/CondVar.pm
@@ -1,5 +1,5 @@
 package AnyEvent::JSONRPC::CondVar;
-use Any::Moose;
+use Moose;
 
 use AnyEvent;
 
@@ -19,7 +19,7 @@ has call => (
     handles  => [qw( is_notification )], 
 );
 
-no Any::Moose;
+no Moose;
 
 sub result {
     my ($self, @result) = @_;

--- a/lib/AnyEvent/JSONRPC/InternalHandle.pm
+++ b/lib/AnyEvent/JSONRPC/InternalHandle.pm
@@ -1,5 +1,5 @@
 package AnyEvent::JSONRPC::InternalHandle;
-use Any::Moose;
+use Moose;
 
 use AnyEvent;
 
@@ -12,7 +12,7 @@ has cv => (
     handles => [qw( recv cb )],
 );
 
-no Any::Moose;
+no Moose;
 
 sub push_write {
     my ($self, $type, $json) = @_;

--- a/lib/AnyEvent/JSONRPC/TCP/Client.pm
+++ b/lib/AnyEvent/JSONRPC/TCP/Client.pm
@@ -1,6 +1,6 @@
 package AnyEvent::JSONRPC::TCP::Client;
-use Any::Moose;
-use Any::Moose '::Util::TypeConstraints';
+use Moose;
+use Moose::Util::TypeConstraints;
 
 extends 'AnyEvent::JSONRPC::Client';
 
@@ -84,7 +84,7 @@ has _connection_guard => (
     isa => 'Object',
 );
 
-no Any::Moose;
+no Moose;
 
 sub BUILD {
     my $self = shift;


### PR DESCRIPTION
If using Any::Moose, you'll run into an error like this:

Any::Moose is deprecated. Please use Moo instead at
/path/to/AnyEvent/JSONRPC/TCP/Client.pm line 2.